### PR TITLE
Rename teams in microservice lab

### DIFF
--- a/07-microservice-architecture/README.md
+++ b/07-microservice-architecture/README.md
@@ -21,9 +21,9 @@ In this lab we are going to deploy multiple services from different teams and ex
 - Limits: `CPU=100m`, `Memory=128Mi`
 - Requests: `CPU=50m`, `Memory=64Mi`
 - env: `TARGET=world, I just woke up!`, `SERVANTS=servant-1,servant-2`
+- Check `Scale to zero`
 - Exposure: `Ingress`
 - Uncheck `Use team domain`
-- Check `Scale to zero`
 - host: `hello-multi` (DNS zone can be left as-is)
 
 Click `Deploy` to start the service and domain registration, as that might take time. Plus we want the service to go to sleep as we intend to wake it up later (it serves a purpose, hope you spot it later on ;).

--- a/07-microservice-architecture/README.md
+++ b/07-microservice-architecture/README.md
@@ -6,11 +6,11 @@ In this lab we are going to deploy multiple services from different teams and ex
 
 1. You are familiar with Knative. Did you try following the [Knative workshop](../04-knative/README.md)?
 2. Knative is enabled in Otomi. (Check the `Apps` section under `Platform`.)
-3. Two teams are created. We will refer to them as `team-a` and `team-b`. (It is not necessary to `Deploy` first.)
+3. Two teams are created. We will refer to them as `alpha` and `beta`. (It is not necessary to `Deploy` first.)
 
 ## Instructions
 
-1. Select team `team-a` in the top bar, select `Services` from the `Team team-a` menu section and click on `Create Service`, and choose `New knative service`.
+1. Select team `alpha` in the top bar, select `Services` from the `Team alpha` menu section and click on `Create Service`, and choose `New knative service`.
 
 2. Provide the following values and `submit`:
 
@@ -40,25 +40,25 @@ Click `Deploy` to start the service and domain registration, as that might take 
 - paths: `/servant-1`
 - env: `TARGET=sir`
  
-5. Select team `team-b` and create a `New knative service` service with the same values but the following diff and `submit`:
+5. Select team `beta` and create a `New knative service` service with the same values but the following diff and `submit`:
 
 - name: `servant-2`
 - paths: `/servant-2`
-- env: `TARGET=sir`, `INFORMANT=informant.team-a` 
+- env: `TARGET=sir`, `INFORMANT=http://informant.team-alpha` 
 
 6. Now click `Deploy Changes` again and watch the deployment finish in Drone.
 
 ## Conclusion
 
-In effect what we have done is create the following workloads for `team-a`:
+In effect what we have done is create the following workloads for team `alpha`:
 
-- `master.team-a` exposed via `https://hello-multi.$domain`
-- `servant-1.team-a` exposed via `https://hello-multi.$domain/servant-1`
-- `informant.team-a` not exposed publicly, but only able to receive requests from `servant-2.team-b`.
+- `master.team-alpha` exposed via `https://hello-multi.$domain`
+- `servant-1.team-alpha` exposed via `https://hello-multi.$domain/servant-1`
+- `informant.team-alpha` not exposed publicly, but only able to receive requests from `servant-2.team-beta`.
 
-And for `team-b`:
+And for team `beta`:
 
-- `servant-2.team-b` exposed via `https://hello-multi.$domain/servant-2`
+- `servant-2.team-beta` exposed via `https://hello-multi.$domain/servant-2`
 
 Bonus: Add network policies to make sure no unforeseen traffic is routed :)
 

--- a/07-microservice-architecture/informant.yaml
+++ b/07-microservice-architecture/informant.yaml
@@ -5,7 +5,7 @@ metadata:
     app: team-ns
     serving.knative.dev/visibility: cluster-local
   name: informant
-  namespace: team-demo
+  namespace: team-alpha
 spec:
   template:
     metadata:

--- a/07-microservice-architecture/servant-1.yaml
+++ b/07-microservice-architecture/servant-1.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: team-ns
   name: servant-1
-  namespace: team-demo
+  namespace: team-alpha
 spec:
   template:
     metadata:

--- a/07-microservice-architecture/servant-2.yaml
+++ b/07-microservice-architecture/servant-2.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: team-ns
   name: servant-2
-  namespace: team-otomi
+  namespace: team-beta
 spec:
   template:
     metadata:

--- a/07-microservice-architecture/sir.yaml
+++ b/07-microservice-architecture/sir.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: team-ns
   name: sir
-  namespace: team-demo
+  namespace: team-alpha
 spec:
   template:
     metadata:


### PR DESCRIPTION
This PR contains two changes to the microservice lab:
* The teams were renamed to `alpha` and `beta` (open for other suggestions). The reason is that if the teams are named `team-a` and `team-b`, the resulting namespaces are expected to be `team-team-a` and `team-team-b`, which is a bit hard to use.
* The `TARGET` variable of the `servant-2` service now has `http://` prepended to the URL. `axios` uses this variable directly to make the outgoing request. Not having this prefix results in a `ECONNREFUSED` exception.