### PR TITLE
Added note on TLS verification of Docker

### DIFF
--- a/05-harbor/README.md
+++ b/05-harbor/README.md
@@ -41,6 +41,11 @@ Log out of Harbor then click "Login via Local DB" with username `otomi-team-demo
 docker login -u 'otomi-team-demo-push' -p <token> harbor.<your-domain>
 ```
 
+> **_NOTE:_** If Docker refuses to connect with an error
+`x509: certificate signed by unknown authority`, go to the Otomi Console,
+and click `Download CA` (if you have not done so already); then copy the
+obtained file to `~/.docker/ca.crt`.
+
 ### 4. Download, build and push the demo application
 
 Clone the repo used for this tutorial:

--- a/05-harbor/README.md
+++ b/05-harbor/README.md
@@ -44,7 +44,7 @@ docker login -u 'otomi-team-demo-push' -p <token> harbor.<your-domain>
 > **_NOTE:_** If Docker refuses to connect with an error
 `x509: certificate signed by unknown authority`, go to the Otomi Console,
 and click `Download CA` (if you have not done so already); then copy the
-obtained file to `~/.docker/ca.crt`.
+obtained file to `~/.docker/ca.crt` or restart docker desktop.
 
 ### 4. Download, build and push the demo application
 


### PR DESCRIPTION
This PR just adds a note on how to make Docker trust the Harbor instance. At least on MacOS, Docker does not access the global trust store. This may be different on Linux or other OS.